### PR TITLE
add #removeTask(identifier, [skipConfig])

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ build
 
 node_modules
 
+*.sublime-project
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ var output = api.init(gruntfileData)
 - [Add global declaration](#add-global-declaration)
 - [Add RAW global declaration](#add-raw-global-declaration)
 - [Register task](#register-task)
+- [Remove task](#remove-task)
 - [Insert task config](#insert-task-config)
 - [Insert RAW task config](#insert-raw-task-config)
 - [Get the updated Gruntfile content](#get-the-updated-gruntfile-content)
@@ -157,6 +158,14 @@ grunt.registerTask('default', function(target) {
 };
 ```
 
+### Remove Task
+
+Remove an existing tasks from the Gruntfile's registered tasks, task lists and configuration.
+
+```
+api.removeTask('someTask');
+api.removeTask('someTask', false); //=> don't remove the task's configuration
+```
 
 ### Insert task config
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -297,7 +297,7 @@
      * Check if traversed node is registerTask body for identifier
      *
      * @param {object} traversalNode
-     * @param {string} identifier
+     * @param {string} [identifier]
      *
      * @return {boolean}
      */
@@ -306,7 +306,8 @@
             isGruntMainBody(traversalNode.parent.parent.parent) &&
             traversalNode.parent.node.callee && traversalNode.parent.node.callee.property &&
             traversalNode.parent.node.callee.property.name === 'registerTask' && traversalNode.key === 'arguments' &&
-            _.isArray(traversalNode.node) && _.first(traversalNode.node).value && _.first(traversalNode.node).value === identifier;
+            _.isArray(traversalNode.node) && _.first(traversalNode.node).value &&
+            (identifier ? _.first(traversalNode.node).value === identifier : true);
     }
 
 
@@ -314,7 +315,7 @@
      * Check traversal position for specified registerTask body
      *
      * @param {object} traversalNode
-     * @param {string} identifier
+     * @param {string} [identifier]
      *
      * @returns {boolean}
      */
@@ -514,7 +515,7 @@
                 this.update(node.concat(syntax));
                 this.stop();
 
-                // task with the same name ist registered.
+                // task with the same name is registered.
                 // 2. option: Task definition is an array and task is array. Prepend, append, or overwrite based on options.
             } else if (isRegisterTaskArguments(this, identifier) && _.isArray(task)) {
                 code = 'var tmp = ' + taskDefinition;
@@ -650,6 +651,42 @@
         });
 
         return exports;
+    }
+
+    /**
+    * Remove task
+    *
+    * @param identifier
+    * @param [stripConfig] - remove configuration too
+    *
+    * @returns {*}
+    */
+    function removeTask(identifier, stripConfig){
+
+        stripConfig = stripConfig || true;
+
+        traversal.forEach(function(node) {
+            if (isRegisterTaskBody(this, identifier)) {
+                // case 1: we're removing a registered task
+                this.parent.parent.remove();
+            } else if (isRegisterTaskArguments(this)) {
+                // case 2: we're removing the task from another task's configuration
+                this.update(node.filter(function(n){
+                    // split the value on `:` to catch tasks like : `watch:less`
+                    n = n.value.split(':')[0];
+                    return n !== identifier;
+                }));
+            } else if (isInitConfigBody(this) && stripConfig) {
+                // case 3: we're removing the task's configuration
+                this.update(node.filter(function(n){
+                   return n.key.name !== identifier;
+                }));
+            }
+        });
+
+
+        return exports;
+
     }
 
     /**
@@ -962,7 +999,7 @@
     exports.addGlobalDeclaration = addGlobalDeclaration;
     exports.addGlobalDeclarationRaw = addGlobalDeclarationRaw;
     exports.registerTask = registerTask;
+    exports.removeTask = removeTask;
     exports.loadNpmTasks = loadNpmTasks;
 
-}))
-;
+}));

--- a/test/removeTask-test.js
+++ b/test/removeTask-test.js
@@ -1,0 +1,43 @@
+/**
+ *
+ * @author Ben Zörb @bezoerb https://github.com/bezoerb
+ * @copyright Copyright (c) 2014 Ben Zörb
+ *
+ * Licensed under the MIT license.
+ * http://bezoerb.mit-license.org/
+ * All rights reserved.
+ */
+'use strict';
+/*jshint -W098 */
+/* global describe, it, before, grunt */
+var api = require('../lib/api.js'),
+    expect = require('chai').expect,
+    assert = require('chai').assert,
+    fs = require('fs'),
+    path = require('path');
+
+
+
+
+api.init(fs.readFileSync(path.join(__dirname, 'fixtures', 'Gruntfile.js'), 'utf-8').toString());
+/*
+ Tests for registerTask
+ */
+describe('removeTask', function() {
+
+    it('should remove the task from registered tasks and configuration', function() {
+
+        var json;
+
+        api.removeTask('default');
+        api.removeTask('build');
+        api.removeTask('plato');
+        json = JSON.parse(api.getJsonTasks());
+        assert.ok(!api.hasTaskRegistered('default'));
+        assert.ok(!api.hasTaskRegistered('build'));
+        assert.ok(!('plato' in json));
+
+    });
+
+});
+


### PR DESCRIPTION
This adds the ability to remove a registered task from the gruntfile by specifying its identifier.

This will also remove the tasks configuration (with toggle) and its references in other tasks.

While this seemed handy when I started writing this I noticed that when done correctly this would also mean removing the task from all other tasks' configuration (which seems more or less impossible/too much work to me).

In case you still think this feature is a good idea one could at least think about adding automatic removal from

``` javascript
grunt.task.run(['taskToBeRemoved', 'otherTask']);
```

before merging this.
